### PR TITLE
Follow up Windows PowerShell quoting fix for dotnet-install.ps1

### DIFF
--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -1,41 +1,39 @@
 --- Installs .NET SDK using Microsoft's official installer script
 --- @param ctx table Context provided by vfox
 function PLUGIN:PostInstall(ctx)
-    local cmd = require("cmd")
-
     local sdkInfo = ctx.sdkInfo["dotnet"]
     local path = sdkInfo.path
     local version = sdkInfo.version
-
-    -- Use correct path separator for OS
     local sep = RUNTIME.osType == "windows" and "\\" or "/"
 
     if RUNTIME.osType == "windows" then
-        -- Windows: Use PowerShell script
+        local function quote_for_windows_shell(value)
+            return '"' .. value:gsub('"', '""') .. '"'
+        end
+
         local scriptPath = path .. sep .. "dotnet-install.ps1"
-        cmd.exec(
-            "powershell -ExecutionPolicy Bypass -File "
-                .. scriptPath
-                .. " -InstallDir "
-                .. path
-                .. " -Version "
-                .. version
-                .. " -NoPath"
-        )
-        -- Clean up installer script
+        local command = "powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File "
+            .. quote_for_windows_shell(scriptPath)
+            .. " -InstallDir "
+            .. quote_for_windows_shell(path)
+            .. " -Version "
+            .. quote_for_windows_shell(version)
+            .. " -NoPath"
+
+        local executeResult = os.execute(command)
+        if executeResult == nil or executeResult == false then
+            error("Failed to execute dotnet-install.ps1 on Windows")
+        end
+
         os.remove(scriptPath)
     else
-        -- Linux/macOS: Use bash script
+        local cmd = require("cmd")
         local scriptPath = path .. sep .. "dotnet-install.sh"
-        -- Make script executable
         cmd.exec("chmod +x '" .. scriptPath .. "'")
-        -- Run the installer
         cmd.exec("'" .. scriptPath .. "' --install-dir '" .. path .. "' --version '" .. version .. "' --no-path")
-        -- Clean up installer script
         os.remove(scriptPath)
     end
 
-    -- Verify installation
     local dotnetBin
     if RUNTIME.osType == "windows" then
         dotnetBin = path .. sep .. "dotnet.exe"

--- a/hooks/post_install.lua
+++ b/hooks/post_install.lua
@@ -1,39 +1,47 @@
 --- Installs .NET SDK using Microsoft's official installer script
 --- @param ctx table Context provided by vfox
 function PLUGIN:PostInstall(ctx)
+    local cmd = require("cmd")
+
     local sdkInfo = ctx.sdkInfo["dotnet"]
     local path = sdkInfo.path
     local version = sdkInfo.version
+
+    -- Use correct path separator for OS
     local sep = RUNTIME.osType == "windows" and "\\" or "/"
 
     if RUNTIME.osType == "windows" then
-        local function quote_for_windows_shell(value)
-            return '"' .. value:gsub('"', '""') .. '"'
+        -- Windows: Use PowerShell script
+        local function quote_for_powershell_literal(value)
+            return "'" .. value:gsub("'", "''") .. "'"
         end
 
         local scriptPath = path .. sep .. "dotnet-install.ps1"
-        local command = "powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File "
-            .. quote_for_windows_shell(scriptPath)
+        local command = 'powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command ". '
+            .. quote_for_powershell_literal(scriptPath)
             .. " -InstallDir "
-            .. quote_for_windows_shell(path)
+            .. quote_for_powershell_literal(path)
             .. " -Version "
-            .. quote_for_windows_shell(version)
-            .. " -NoPath"
-
-        local executeResult = os.execute(command)
-        if executeResult == nil or executeResult == false then
-            error("Failed to execute dotnet-install.ps1 on Windows")
+            .. quote_for_powershell_literal(version)
+            .. ' -NoPath"'
+        local executeOk, _, executeCode = os.execute(command)
+        if not ((type(executeOk) == "number" and executeOk == 0) or (executeOk == true and (executeCode == nil or executeCode == 0))) then
+            error("Failed to execute dotnet-install.ps1 on Windows: " .. tostring(executeCode or executeOk))
         end
-
+        -- Clean up installer script
         os.remove(scriptPath)
     else
-        local cmd = require("cmd")
+        -- Linux/macOS: Use bash script
         local scriptPath = path .. sep .. "dotnet-install.sh"
+        -- Make script executable
         cmd.exec("chmod +x '" .. scriptPath .. "'")
+        -- Run the installer
         cmd.exec("'" .. scriptPath .. "' --install-dir '" .. path .. "' --version '" .. version .. "' --no-path")
+        -- Clean up installer script
         os.remove(scriptPath)
     end
 
+    -- Verify installation
     local dotnetBin
     if RUNTIME.osType == "windows" then
         dotnetBin = path .. sep .. "dotnet.exe"


### PR DESCRIPTION
## Summary

Follow up #6 by switching the Windows installer path from a quoted PowerShell `-File` invocation to a PowerShell `-Command` wrapper that safely single-quotes the script path, install dir, and version.

## Why this follow-up is needed

`main` currently has the earlier partial fix from #6:

```lua
local command = "powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File "
    .. quote_for_windows_shell(scriptPath)
    .. " -InstallDir "
    .. quote_for_windows_shell(path)
    .. " -Version "
    .. quote_for_windows_shell(version)
    .. " -NoPath"
```

That still fails in my Windows Server 2025 / Windows PowerShell 5.1 repro because the runtime ends up handing PowerShell a malformed `-File` argument:

```text
Processing -File '"C:\Users\ContainerAdministrator\AppData\Local\mise\installs\dotnet\10.0.201\dotnet-install.ps1"' failed: Illegal characters in path.
```

The exact command shape involved is:

```text
powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File "C:\Users\ContainerAdministrator\AppData\Local\mise\installs\dotnet\10.0.201\dotnet-install.ps1" -InstallDir "C:\Users\ContainerAdministrator\AppData\Local\mise\installs\dotnet\10.0.201" -Version "10.0.201" -NoPath
```

Using `-Command ". '...ps1' ..."` avoids that extra quote layer while still calling the same official Microsoft installer script.

## What changed

- keep the existing Unix `cmd.exec(...)` path unchanged
- keep `cmd` required at the top of the function, matching the bot feedback and upstream structure
- switch the Windows branch to:
  - PowerShell `-Command`
  - single-quoted PowerShell literals for `scriptPath`, `path`, and `version`
- keep `os.execute(...)`, but make the return-value handling robust for both:
  - Lua 5.1 numeric status returns
  - newer boolean plus exit-code return shapes

## Validation

I validated this in a runner-like Windows Server 2025 Docker container with Windows PowerShell 5.1 by running:

```powershell
mise install dotnet@10.0.201
```

and then reran my full Windows bootstrap smoke test around it. With this follow-up patch:

- `mise install dotnet@10.0.201` succeeds
- `dotnet --version` resolves to `10.0.201`
- the second bootstrap run stays idempotent without redownloading the toolchain

## Notes

I also checked the broader vfox ecosystem before keeping `os.execute(...)` here. The official `version-fox/vfox-erlang` plugin already uses `os.execute(...)` in its Windows installer path, so this stays within an existing Windows-plugin pattern rather than inventing a new one.
